### PR TITLE
font-awesome-sass削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,5 @@ gem 'haml-rails'
 gem 'erb2haml'
 gem 'jquery-turbolinks'
 gem 'mysql2', '>= 0.3.18', '< 0.6.0'
-gem 'font-awesome-sass', '~> 5.8.1'
-gem 'sassc-rails'
 
 


### PR DESCRIPTION
#what
font-awesome-sass gemの削除
#why
自動デプロイ時にfont-awesome-sass gemが原因のエラーが発生し、masterブランチの内容を変更して正常に動作するか確認する必要があるため