### PR TITLE
Uglifier::Error: Unexpected character '`'エラー解消

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# why
自動デプロイ時のUglifier::Error: Unexpected character '`'エラーを解決するため特定の記述をコメントアウト
http://taremimi.hatenablog.jp/entry/2018/03/31/044914