### PR TITLE
user登録id削除

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -164,5 +164,5 @@
             .registar4-main__content__form__seqcode__about
               =link_to'カード裏面の番号とは?', class: 'registar4-main__content__form__seqcode__about' 
           .actions
-            = f.submit '次へ進む', class: 'registar4-main__content__form__next', id: 'token_submit'
+            = f.submit '次へ進む', class: 'registar4-main__content__form__next'
 = render 'templates/single-footer'


### PR DESCRIPTION
#WHAT
ユーザー登録からid属性削除

#WHY
カード登録の際に実装したが不要となりユーザー登録を妨げたため。